### PR TITLE
memory.md calloc change paramter describe

### DIFF
--- a/docs/memory.md
+++ b/docs/memory.md
@@ -157,7 +157,7 @@ void gobble(double arr[], int n) {
 
 两者的区别主要有两点：
 
-（1）`calloc()`接受两个参数，第一个参数是数据类型的单位字节长度，第二个是该数据类型的数量。
+（1）`calloc()`接受两个参数，第一个参数是所需数据类型的数量，第二个是该数据类型的单位字节长度。
 
 ```c
 void* calloc(size_t n, size_t size);


### PR DESCRIPTION
`memory.md`中`calloc()`参数说明错误

原文：
```
calloc()接受两个参数，第一个参数是数据类型的单位字节长度，第二个是该数据类型的数量
```

此处参数说明应该是反过来。

贴下官方的API文档：

<img width="1200" alt="Screen Shot 2021-10-17 at 19 25 14" src="https://user-images.githubusercontent.com/76166790/137625552-89246684-b026-4b74-bb1f-1893dae7637f.png">